### PR TITLE
fixed score and matchmaking bugs

### DIFF
--- a/truco-front/src/App.tsx
+++ b/truco-front/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
             <Route path="/play" element={<InGame />} />
             <Route path="/profile" element={<Profile />} />
             <Route path="/leader-board" element={<LeaderBoard />} />
-            <Route path="/roules" element={<Rules />} />
+            <Route path="/rules" element={<Rules />} />
             <Route path="/login" element={<LogIn />} />
             <Route path="/signup" element={<SignUp />} />
           </Routes>

--- a/truco-front/src/components/matchmaking/PlayNowButton.tsx
+++ b/truco-front/src/components/matchmaking/PlayNowButton.tsx
@@ -20,6 +20,7 @@ const PlayNowButton = () => {
   useEffect(() => {
     if (gameEnded) {
       setIsSearching(false)
+      setGameEnded(false)
       isSearchingRef.current = false
     }
   }, [gameEnded])

--- a/truco-front/src/components/navbarElements/HowToPlayButton.tsx
+++ b/truco-front/src/components/navbarElements/HowToPlayButton.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 const HowToPlayButton: React.FC = () => {
   return (
 
-    <Link to="/roules" 
+    <Link to="/rules"
       className='w-[80%] h-[40px] bg-primary rounded-lg flex justify-center items-center' >
       <h2 className='text-lg'>How to play</h2>
 

--- a/truco-front/src/hooks/usePusherListeners.ts
+++ b/truco-front/src/hooks/usePusherListeners.ts
@@ -91,6 +91,8 @@ export const usePusherListeners = (
             setIsMyTurn(false)
             setActions([])
             setOpponentName("")
+            setMyPoints(0)
+            setOpponentPoints(0)
             setCards((prev) => prev.map(() => null))
             setOpponentCardsNumber(0)
             setCardsOnBoard((prev) => prev.map(() => null))


### PR DESCRIPTION

## Motivation

Closes #65 

## Summary of changes

* reset score to 0 on game end so that it starts from 0 in the next match
* reset propperly `isSearching` to false in PlayNowButton on game end
* fixed typo in /rules route (it was called /roules)

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] Unit tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
